### PR TITLE
AP_Mount_Alexmos: critical fix to avoid endless loop if byte arrive too fast in serial buffer

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -214,7 +214,10 @@ void AP_Mount_Alexmos::parse_body()
 void AP_Mount_Alexmos::read_incoming()
 {
     uint8_t data;
-    while (_port->available()) {
+    int16_t numc;
+
+    numc = _port->available();
+    for (int16_t i = 0; i < numc; i++) {        // Process bytes received
         data = _port->read();
         switch (_step) {
             case 0:


### PR DESCRIPTION
This fix reads the number of bytes available and iterates on it instead of looking for new bytes in the serial buffer (potentially forever)