### PR TITLE
Rover: Add rover MIS_DONE_BEHAVE parame

### DIFF
--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -204,7 +204,6 @@ public:
         k_param_notify,
         k_param_button,
         k_param_osd,
-        k_param_mis_done_behave,
 
         k_param_DataFlash = 253,  // Logging Group
 

--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -34,6 +34,6 @@ Rover::Rover(void) :
     control_mode(&mode_initializing),
     home(ahrs.get_home()),
     G_Dt(0.02f),
-    mode_auto(mode_loiter, mode_rtl)
+    mode_auto(mode_rtl)
 {
 }

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -443,7 +443,6 @@ private:
     void do_change_speed(const AP_Mission::Mission_Command& cmd);
     void do_set_home(const AP_Mission::Mission_Command& cmd);
     void do_set_reverse(const AP_Mission::Mission_Command& cmd);
-    uint8_t get_mis_done_behave() { return g2.mis_done_behave.get(); }
 
     enum Mis_Done_Behave {
         Mis_Done_Behave_Hold      = 0,

--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -109,11 +109,11 @@ void Rover::exit_mission()
     // send message
     gcs().send_text(MAV_SEVERITY_NOTICE, "Mission Complete");
 
-    if (get_mis_done_behave() == Mis_Done_Behave_Hold) {
-        set_mode(mode_hold, MODE_REASON_MISSION_END);
-    } else if (!mode_auto.loiter_start()) {
-        set_mode(mode_hold, MODE_REASON_MISSION_END);
+    if (g2.mis_done_behave == Mis_Done_Behave_Loiter) {
+        set_mode(mode_loiter, MODE_REASON_MISSION_END);
+        return;
     }
+    set_mode(mode_hold, MODE_REASON_MISSION_END);
 }
 
 // verify_command_callback - callback function called from ap-mission at 10hz or higher when a command is being run

--- a/APMrover2/mode.h
+++ b/APMrover2/mode.h
@@ -10,7 +10,6 @@
 #define MODE_NEXT_HEADING_UNKNOWN   99999.0f    // used to indicate to set_desired_location method that next leg's heading is unknown
 
 // pre-define ModeRTL so Auto can appear higher in this file
-class ModeLoiter;
 class ModeRTL;
 
 class Mode
@@ -237,7 +236,7 @@ class ModeAuto : public Mode
 public:
 
     // constructor
-    ModeAuto(ModeLoiter& mode_loiter, ModeRTL& mode_rtl);
+    ModeAuto(ModeRTL& mode_rtl);
 
     uint32_t mode_number() const override { return AUTO; }
     const char *name4() const override { return "AUTO"; }
@@ -260,8 +259,6 @@ public:
     void set_desired_heading_and_speed(float yaw_angle_cd, float target_speed) override;
     bool reached_heading();
 
-    // start loiter
-    bool loiter_start();
     // start RTL (within auto)
     void start_RTL();
 
@@ -273,7 +270,6 @@ protected:
     enum AutoSubMode {
         Auto_WP,                // drive to a given location
         Auto_HeadingAndSpeed,   // turn to a given heading
-        Auto_Loiter,            // perform Loiter within auto mode
         Auto_RTL                // perform RTL within auto mode
     } _submode;
 
@@ -282,7 +278,6 @@ private:
     bool check_trigger(void);
 
     // references
-    ModeLoiter& _mode_loiter;
     ModeRTL& _mode_rtl;
 
     // this is set to true when auto has been triggered to start

--- a/APMrover2/mode_auto.cpp
+++ b/APMrover2/mode_auto.cpp
@@ -2,8 +2,7 @@
 #include "Rover.h"
 
 // constructor
-ModeAuto::ModeAuto(ModeLoiter& mode_loiter, ModeRTL& mode_rtl) :
-    _mode_loiter(mode_loiter),
+ModeAuto::ModeAuto(ModeRTL& mode_rtl) :
     _mode_rtl(mode_rtl)
 {
 }
@@ -76,10 +75,6 @@ void ModeAuto::update()
             break;
         }
 
-        case Auto_Loiter:
-            _mode_loiter.update();
-            break;
-
         case Auto_RTL:
             _mode_rtl.update();
             break;
@@ -137,27 +132,6 @@ bool ModeAuto::reached_heading()
     return true;
 }
 
-// start loiter
-bool ModeAuto::loiter_start()
-{
-    // return failure if frame is not boat
-    if (!rover.is_boat()) {
-        return false;
-    }
-
-    // return failure if position is bad
-    nav_filter_status filt_status;
-    if (!rover.position_ok(filt_status)) {
-        return false;
-    }  
-
-    _submode = Auto_Loiter;
-
-    // calculate stopping destination
-    calc_stopping_location(_destination);
-
-    return true;    
-}
 
 // start RTL (within auto)
 void ModeAuto::start_RTL()


### PR DESCRIPTION
@rmackay9 Thank you for review my PR. I made the corrections simple. The MIS_DONE_BEHAVE parameter controls only the mode of exit_mission. First of all we will PR to Randy's repository. Please re-review.