### PR TITLE
Remove parameter conversion on Plane to save space

### DIFF
--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,5 +1,31 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
+Copter 4.3.2-rc1 13-Dec-2022
+Changes from 4.3.1
+1) Arming check that main loop is running at configured speed (e.g. SCHED_LOOP_RATE)
+2) uBlox M10 support
+3) Bug fixes
+    a) AutoTune gains loaded correctly during pilot testing
+    b) Camera driver's CAM_MIN_INTERVAL fixed if pilot manually triggers extra picture
+    c) EKF3 fix when using EK3_RNG_USE_HGT/SPD params and rangefinder provides bad readings
+    d) Main loop slowdown after arming fixed (parameter logging was causing delays)
+    e) Main loop's fast tasks always run (caused twitches in Loiter on heavily loaded CPUs)
+    f) MAVLink commands received on private channels checked for valid target sysid
+    g) ModalAI cameras support fixed (ODOMETRY message frame was consumed incorrectly)
+    h) Param reset after firmware load fixed on these boards
+        - BeastF7v2
+        - CubeYellow-bdshot
+        - f405-MatekAirspeed
+        - FlywooF745Nano
+        - KakuteF4Mini
+        - KakuteF7-bdshot
+        - MatekF405-bdshot
+        - MatekF405-STD
+        - MatekF405-Wing-bdshot
+        - MatekF765-SE
+        - MatekF765-Wing-bdshot
+    i) Siyi A8 gimbal support fixed
+------------------------------------------------------------------
 Copter 4.3.1 05-Dec-2022 / 4.3.1-rc1 17-Nov-2022
 Changes from 4.3.0
 1) Autopilot specific enhancements

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.3.1"
+#define THISFIRMWARE "ArduCopter V4.3.2-rc1"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,1,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,3,1,FIRMWARE_VERSION_TYPE_RC
 
 #define FW_MAJOR 4
 #define FW_MINOR 3
-#define FW_PATCH 1
-#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FW_PATCH 2
+#define FW_TYPE FIRMWARE_VERSION_TYPE_RC
 
 #include <AP_Common/AP_FWVersionDefine.h>

--- a/Rover/release-notes.txt
+++ b/Rover/release-notes.txt
@@ -1,5 +1,29 @@
 Rover Release Notes:
 ------------------------------------------------------------------
+Rover 4.3.0-beta6 13-Dec-2022
+Changes from 4.3.0-beta5
+1) Arming check that main loop is running at configured speed (e.g. SCHED_LOOP_RATE)
+2) uBlox M10 support
+3) Bug fixes
+    a) Camera driver's CAM_MIN_INTERVAL fixed if pilot manually triggers extra picture
+    b) Main loop slowdown after arming fixed (parameter logging was causing delays)
+    c) Main loop's fast tasks always run (caused twitches in Loiter on heavily loaded CPUs)
+    d) MAVLink commands received on private channels checked for valid target sysid
+    e) ModalAI cameras support fixed (ODOMETRY message frame was consumed incorrectly)
+    f) Param reset after firmware load fixed on these boards
+        - BeastF7v2
+        - CubeYellow-bdshot
+        - f405-MatekAirspeed
+        - FlywooF745Nano
+        - KakuteF4Mini
+        - KakuteF7-bdshot
+        - MatekF405-bdshot
+        - MatekF405-STD
+        - MatekF405-Wing-bdshot
+        - MatekF765-SE
+        - MatekF765-Wing-bdshot
+    g) Siyi A8 gimbal support fixed
+------------------------------------------------------------------
 Rover 4.3.0-beta5 17-Nov-2022
 Changes from 4.3.0-beta4
 1) Autopilot specific enhancements

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,10 +6,10 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.3.0-beta5"
+#define THISFIRMWARE "ArduRover V4.3.0-beta6"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_BETA+5
+#define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_BETA+6
 
 #define FW_MAJOR 4
 #define FW_MINOR 3

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -365,7 +365,7 @@ void AP_Airspeed::init()
         param[0].type.set_default(TYPE_ANALOG);
     }
 
-#ifndef HAL_BUILD_AP_PERIPH
+#if !defined(HAL_BUILD_AP_PERIPH) && !APM_BUILD_TYPE(APM_BUILD_ArduPlane)
     // Switch to dedicated WIND_MAX param
     // PARAMETER_CONVERSION - Added: Oct-2020
     const float ahrs_max_wind = AP::ahrs().get_max_wind();

--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -110,6 +110,7 @@ PARAMETER_CONVERSION - Added: Aug-2021
 */
 void AP_RPM::convert_params(void)
 {
+#if !APM_BUILD_TYPE(APM_BUILD_ArduPlane)
     if (_params[0].type.configured()) {
         // _params[0].type will always be configured after conversion is done the first time
         return;
@@ -176,6 +177,7 @@ void AP_RPM::convert_params(void)
 
     // force _params[0].type into storage to flag that conversion has been done
     _params[0].type.save(true);
+#endif
 }
 
 /*

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -177,6 +177,7 @@ RangeFinder::RangeFinder()
 }
 
 void RangeFinder::convert_params(void) {
+#if !APM_BUILD_TYPE(APM_BUILD_ArduPlane)
     if (params[0].type.configured()) {
         // _params[0]._type will always be configured after conversion is done the first time
         // or the user has set a type in a defaults.parm file or via apj tool
@@ -256,6 +257,7 @@ void RangeFinder::convert_params(void) {
 
     // force _params[0]._type into storage to flag that conversion has been done
     params[0].type.save(true);
+#endif
 }
 
 /*


### PR DESCRIPTION
Backporting of various fixes, and in particular the better M10 support overflowed MatekF405-Wing.
