### PR TITLE
Plane: tailsitter: ensure none-masked motors are zeroed in forward flight

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -289,6 +289,12 @@ void Tailsitter::output(void)
         return;
     }
 
+    if (!hal.util->get_soft_armed() ||
+        SRV_Channels::get_emergency_stop()) {
+        // Ensure motors stop on disarm
+        motors->output_min();
+    }
+
     float tilt_left = 0.0f;
     float tilt_right = 0.0f;
 


### PR DESCRIPTION
backport of https://github.com/ArduPilot/ardupilot/pull/29561